### PR TITLE
Go through all pages looking for modifiers

### DIFF
--- a/lib/processSketch.js
+++ b/lib/processSketch.js
@@ -90,8 +90,13 @@ can also target more specific atoms eg. home/footer/primaryButton[selected]/back
 */
 const extractModifiers = (sketch) => {
     //TODO: This could probably be more efficient as a `reduce`
-    const modifiers = sketch.getPages()[0].layers.filter((layer) => {
-        return layer.name.includes("--")
+    const pages = sketch.getPages()
+    let modifiers = []
+    pages.forEach(page => {
+        const pageModifiers = page.layers.filter((layer) => {
+            return layer.name.includes("--")
+        })
+        modifiers = modifiers.concat(pageModifiers)
     })
     // Take all modifiers and add them to a dictionary keyed by the modifier ID
     let d = {}


### PR DESCRIPTION
Traverses all pages in the sketch document looking for modifiers, not just the first page.