### PR TITLE
Add support for SVG output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ $ npm install
 ## Features
 
 - Extracts layer styles, text styles and assets from a Sketch file.
+- Allows output of assets to be in PDF form or SVG
 
 ## Usage (Optional)
 
 ```shell
 npm run convert ${path-to-sketch-file.sketch}
+```
+
+or if you want your assets as SVG:
+```shell
+npm run convert -- ${path-to-sketch-file.sketch} --svg
 ```
 
 ## Documentation (Optional)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,8 +15,13 @@ const argv = require('yargs')
     .nargs('o', 1)
     .default('o', `./output`)
     .describe('o', 'Folder to output the swift code and assets.')
+    .option('svg', {
+        type: 'boolean',
+        default: false,
+        description: 'Export the assets of mysketchfile.sketch as SVG files'
+    })
     .demandCommand(1)
     .help('help')
     .argv
 
-convertSketchToSwiftUI(argv['file'], argv['o'])
+convertSketchToSwiftUI(argv['file'], argv['o'], argv['svg'])

--- a/lib/processAssets.js
+++ b/lib/processAssets.js
@@ -1,33 +1,31 @@
-const { flattenName, prepareAssetBundleForPDF} = require('./processShared')
+const { flattenName, prepareAssetBundleForPDF, prepareAssetBundleForSVG} = require('./processShared')
 const svg = require('sketch-to-svg')
 const fs = require('fs')
 const pdfDoc = require('pdfkit')
 const SVGtoPDF = require('svg-to-pdfkit')
 const path = require('path')
 
-async function processAssets(layers, filepath, outputFolder) {
-  let css = []
+async function processAssets(layers, filepath, outputFolder, outputAsSVG) {
+  let assets = []
 
-  let assetBundleFolder = createAssetBundle(outputFolder)
+  const assetBundleFolder = createAssetBundle(outputFolder)
 
   for (let index = 0; index < layers.length; ++index) {
-    let layer = layers[index]
-    let backgroundImage = await assetToSvg(layer, filepath, outputFolder, flattenName(layer.name))
-    let filePath = prepareAssetBundleForPDF(assetBundleFolder, flattenName(layer.name))
-    svgToPdf(backgroundImage, filePath, {width: assetWidth(layer), height: assetHeight(layer)})
-    css.push({
+    const layer = layers[index]
+    const backgroundImage = await assetToSvg(layer, filepath, outputFolder, flattenName(layer.name))
+    if (outputAsSVG) {
+      const assetPath = prepareAssetBundleForSVG(assetBundleFolder, flattenName(layer.name))
+      fs.writeFileSync(assetPath, backgroundImage)
+    } else {
+      const assetPath = prepareAssetBundleForPDF(assetBundleFolder, flattenName(layer.name))
+      svgToPdf(backgroundImage, assetPath, {width: assetWidth(layer), height: assetHeight(layer)})
+    }
+    assets.push({
       name: flattenName(layer.name),
-      css: [
-        { name: "background-image", value: backgroundImage },
-        { name: "background-repeat", value: "no-repeat" },
-        { name: "background-position", value: "center" },
-        { name: "width", value: assetWidth(layer) },
-        { name: "height", value: assetHeight(layer) }
-      ]
     })
   }
 
-  return css
+  return assets
 }
 
 /**

--- a/lib/processShared.js
+++ b/lib/processShared.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 const addOptionalProperty = (name, array, value) => {
     if (value) {
@@ -42,18 +43,25 @@ const prepareAssetBundleForPNG = (assetBundleFolder, name) => {
     return prepareAssetBundleForAsset(assetBundleFolder, name, '.png')
 }
 
+const prepareAssetBundleForSVG = (assetBundleFolder, name) => {
+    return prepareAssetBundleForAsset(assetBundleFolder, name, '.svg')
+}
+
 const prepareAssetBundleForAsset = (assetBundleFolder, name, extension) => {
-    //let name = path.basename(filename, ".pdf")
-    let folder = `${assetBundleFolder}/${name}.imageset/`
+    let folder = path.join(assetBundleFolder, `${name}.imageset/`)
     fs.mkdirSync(folder, { recursive: true })
-    let json = JSON.stringify({
+    let fileContents = {
         images: [
             { idiom: "universal", 
             filename: `${name}${extension}` }
         ],
         info: { version:1, author:"sketch-to-swiftui" }, 
         properties: { "template-rendering-intent": "original" }
-    })
+    }
+    if (extension == ".svg") {
+        fileContents.properties = { "preserves-vector-representation" : true }
+    }
+    let json = JSON.stringify(fileContents)
     fs.writeFileSync(folder + "Contents.json", json)
     return folder + name + extension
 }
@@ -64,5 +72,6 @@ module.exports = { addOptionalProperty: addOptionalProperty,
     doRound: doRound, 
     colorToRGBA: colorToRGBA,
     prepareAssetBundleForPDF,
-    prepareAssetBundleForPNG
+    prepareAssetBundleForPNG,
+    prepareAssetBundleForSVG
 }

--- a/lib/processSketch.js
+++ b/lib/processSketch.js
@@ -9,7 +9,7 @@ const util = require('util')
  * @param {*} filepath A path to the sketch file so we can extract assets if we need to
  * @param {*} outputFolder The folder to output any resources if we need to
  */
-async function processSketchFile(sketch, filepath, outputFolder) {
+async function processSketchFile(sketch, filepath, outputFolder, outputAsSVG) {
 
     // console.log(util.inspect(sketch.getLayerStyles(), {showHidden: false, depth: null}))
     // console.log(util.inspect(sketch.getTextStyles(), {showHidden: false, depth: null}))
@@ -28,7 +28,7 @@ async function processSketchFile(sketch, filepath, outputFolder) {
     console.log(`    📝 Processed ${textStyles.text.swiftUIStyles.length} Text Styles!\n`)
 
     let assetLayers = sketch.pages.flatMap(page => page.layers.filter(layer => layer._class === "symbolMaster" && layer.name != "Button/Shape"))
-    let assets = await processAssets(assetLayers, filepath, outputFolder)
+    let assets = await processAssets(assetLayers, filepath, outputFolder, outputAsSVG)
     console.log(`    🖼️  Processed ${assets.length} Assets!\n`)
 
     styles.styles = merge(textStyles.text.swiftUIStyles, layers.swiftUIStyles)

--- a/sketchToSwiftUI.js
+++ b/sketchToSwiftUI.js
@@ -3,11 +3,11 @@ const { processSketchFile } = require('./lib/processSketch')
 const { generateSwiftUI } = require('./lib/generateSwiftUI')
 const fs = require('fs')
 
-function convertSketchToSwiftUI(filename, outputFolder) {
-    //console.log("Extracting from " + filename + " to " + outputFolder)
+function convertSketchToSwiftUI(filename, outputFolder, outputAsSVG) {
+    // console.log("Extracting from " + filename + " to " + outputFolder)
     Sketch.fromFile(filename)
         .then(sketch => {
-            return processSketchFile(sketch, filename, outputFolder)
+            return processSketchFile(sketch, filename, outputFolder, outputAsSVG)
         })
         .then(styles => {
             fs.mkdirSync(outputFolder, { recursive: true })


### PR DESCRIPTION
iOS 14 adds support for SVG assets, so if you want you can export your assets as SVG instead of PDF. This saves a step in the library. Additionally, SwiftUI in iOS 14 has a bug where PDFs are rendered as bitmaps and then up-scaled so they're blurry :mega_sigh:

@atomoil troll away