### PR TITLE
Reverse ordering of layer styles

### DIFF
--- a/lib/processLayerStyles.js
+++ b/lib/processLayerStyles.js
@@ -62,6 +62,10 @@ const processLayerStyles = async (layerStyles, filepath, outputFolder, modifiers
 module.exports = {processLayerStyles: processLayerStyles}
 
 const getBestMatchingModifier = (style, radius) => {
+  const initialValue = {modifier: null, score: 0}
+  if (!radius) {
+    return initialValue
+  }
   return radius.reduce((accumulator, currentValue) => {
     const modName = getModifierNameWithoutModifier(currentValue);
     const score = matchScore(style.name, modName)
@@ -69,7 +73,7 @@ const getBestMatchingModifier = (style, radius) => {
       return {modifier: currentValue, score: score}
     }
     return accumulator
-  }, {modifier: null, score: 0})
+  }, initialValue)
 }
 
 const getModifierNameWithoutModifier = (modifier) => {
@@ -177,6 +181,9 @@ const layerFillWithShadows = (layerStyle, outputFolder, sketchFile) => {
           }
         }
       }
+      // SwiftUI applies backgrounds in reverse-order of how they are added, but we want to maintain
+      // the order that is sent from Sketch, so we revert the backgroundArray here
+      backgroundArray = backgroundArray.reverse()
       // Check to see if there is a shadow
       // If there is a shadow
       // -- take the last item added to the background Array and add the shadow to it

--- a/lib/processLayerStyles.js
+++ b/lib/processLayerStyles.js
@@ -181,9 +181,14 @@ const layerFillWithShadows = (layerStyle, outputFolder, sketchFile) => {
           }
         }
       }
-      // SwiftUI applies backgrounds in reverse-order of how they are added, but we want to maintain
-      // the order that is sent from Sketch, so we revert the backgroundArray here
-      backgroundArray = backgroundArray.reverse()
+      // If there is more than one background to be applied, we take the first one and add the rest as `overlays` of it
+      if (backgroundArray.length > 1) {
+        let firstItem = backgroundArray.shift()
+        let overlays = backgroundArray.map((background) => {
+          return `.overlay(${background})`
+        })
+        backgroundArray = firstItem + overlays.join("")
+      }
       // Check to see if there is a shadow
       // If there is a shadow
       // -- take the last item added to the background Array and add the shadow to it
@@ -198,7 +203,7 @@ const layerFillWithShadows = (layerStyle, outputFolder, sketchFile) => {
             }
           }
           let lastBackground = backgroundArray.pop();
-          lastBackground = lastBackground + shadowArray.join();
+          lastBackground = lastBackground + shadowArray.join("");
           backgroundArray.push(lastBackground);
       }
       return backgroundArray


### PR DESCRIPTION
The latest Sketch produces the array of layers in the order that they are in the sketch document. Unfortunately, that means that in SwiftUI we need to reverse the applying of the view modifiers to match the sketch doc. For example:

A sketch document with 2 layers: a background and an image on top will be represented in the sketch doc as an array of layers like [color, image] which yields SwiftUI code like:

```swift
AnyView($0
    .background(Color(red: 0.95, green: 0.95, blue: 0.95, opacity: 1))
    .background(Image("f1caef7f83c2b6138b3b5397622c73f0a1ef053c", bundle: nil).resizable().aspectRatio(contentMode: .fill))
)
```
However, in SwiftUI that is the reverse of the ordering we require. This PR reverses the final background array.

There will be forthcoming PRs to do the same with shadows and borders if following some tests it is revealed that they are required to be reversed too.