### PR TITLE
Add support for extracting themes

### DIFF
--- a/lib/processSketch.js
+++ b/lib/processSketch.js
@@ -37,7 +37,10 @@ async function processSketchFile(sketch, filepath, outputFolder, outputAsSVG) {
     styles.uiKitProps = mergeProperties(textStyles.text.uiKitProperties, layers.uiKitProperties)
     styles.uiKitProps.sort(sortByName)
 
-    styles.theming = { themes: extractThemes(sketch) }
+    const themes = extractThemes(sketch)
+    // + 1 because we have the "default" theme too
+    console.log(`    Found ${themes.length + 1} theme(s)`)
+    styles.theming = { themes }
 
     return styles
 }
@@ -116,16 +119,21 @@ const extractModifiers = (sketch) => {
 // Extracts the themes from a sketch file
 // A theme is found if an identifier starts with an @ symbol.
 const extractThemes = (sketch) => {
-    const pages = sketch.getPages()
     let themes = []
-    pages.forEach(page => {
-        const layerThemes = page.layers.filter((layer) => {
-            return layer.name.startsWith("@")
-        }).map((item) => {
-            return item.split("/")[0]
-        })
-        themes = themes.concat(layerThemes)
-    })
+    const themeExtraction = (style) => {
+        if (style.name.startsWith("@")) {
+            const themeName = style.name.split("/")[0]
+            if (!themes.includes(themeName)) {
+                themes.push(themeName)
+            }
+        }
+    }
+    const textStyles = sketch.getTextStyles()
+    textStyles.forEach(themeExtraction)
+
+    const layerStyles = sketch.getLayerStyles()
+    layerStyles.forEach(themeExtraction)
+
     return themes.map((name) => {
         // The varName drops the @ at the beginning and camelcases
         return { varName: camelCase(name.substring(1)), name }

--- a/lib/processSketch.js
+++ b/lib/processSketch.js
@@ -135,8 +135,8 @@ const extractThemes = (sketch) => {
     layerStyles.forEach(themeExtraction)
 
     return themes.map((name) => {
-        // The varName drops the @ at the beginning and camelcases
-        return { varName: camelCase(name.substring(1)), name }
+        // The name drops the @ at the beginning
+        return { name: name.substring(1) }
     })
 }
 

--- a/lib/processSketch.js
+++ b/lib/processSketch.js
@@ -2,6 +2,7 @@ const { processLayerStyles } = require('./processLayerStyles')
 const { processTextStyles } = require('./processTextStyles')
 const { processAssets } = require('./processAssets')
 const util = require('util')
+const camelCase = require('camelcase');
 
 /**
  *
@@ -35,6 +36,8 @@ async function processSketchFile(sketch, filepath, outputFolder, outputAsSVG) {
     styles.styles.sort(sortByName)
     styles.uiKitProps = mergeProperties(textStyles.text.uiKitProperties, layers.uiKitProperties)
     styles.uiKitProps.sort(sortByName)
+
+    styles.theming = { themes: extractThemes(sketch) }
 
     return styles
 }
@@ -108,6 +111,25 @@ const extractModifiers = (sketch) => {
         d[modifierId].push(modifier)
     })
     return d
+}
+
+// Extracts the themes from a sketch file
+// A theme is found if an identifier starts with an @ symbol.
+const extractThemes = (sketch) => {
+    const pages = sketch.getPages()
+    let themes = []
+    pages.forEach(page => {
+        const layerThemes = page.layers.filter((layer) => {
+            return layer.name.startsWith("@")
+        }).map((item) => {
+            return item.split("/")[0]
+        })
+        themes = themes.concat(layerThemes)
+    })
+    return themes.map((name) => {
+        // The varName drops the @ at the beginning and camelcases
+        return { varName: camelCase(name.substring(1)), name }
+    })
 }
 
 module.exports = {processSketchFile: processSketchFile}

--- a/lib/template.hb.swift
+++ b/lib/template.hb.swift
@@ -132,7 +132,7 @@ struct RoundedCorners: Shape {
 // Add support for themes
 extension Theme {
     {{#each theming.themes}}
-    static let {{{ varName }}} = Theme(name: "{{{ name }}}")
+    static let {{{ name }}} = Theme(name: "{{{ name }}}")
     {{/each}}
 }
 {{/if}}

--- a/lib/template.hb.swift
+++ b/lib/template.hb.swift
@@ -128,13 +128,11 @@ struct RoundedCorners: Shape {
     }
 }
 
-{{#if theming}}
 // Add support for themes
 extension Theme {
     {{#each theming.themes}}
     static let {{{ name }}} = Theme(name: "{{{ name }}}")
     {{/each}}
 }
-{{/if}}
 
 // swiftlint:enable all

--- a/lib/template.hb.swift
+++ b/lib/template.hb.swift
@@ -128,4 +128,13 @@ struct RoundedCorners: Shape {
     }
 }
 
+{{#if theming}}
+// Add support for themes
+extension Stylist.Theme {
+    {{#each theming.themes}}
+    static let {{{ varName }}} = Stylist.Theme(name: "{{{ name }}}")
+    {{/each}}
+}
+{{/if}}
+
 // swiftlint:enable all

--- a/lib/template.hb.swift
+++ b/lib/template.hb.swift
@@ -130,9 +130,9 @@ struct RoundedCorners: Shape {
 
 {{#if theming}}
 // Add support for themes
-extension Stylist.Theme {
+extension Theme {
     {{#each theming.themes}}
-    static let {{{ varName }}} = Stylist.Theme(name: "{{{ name }}}")
+    static let {{{ varName }}} = Theme(name: "{{{ name }}}")
     {{/each}}
 }
 {{/if}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -442,6 +442,14 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
       }
     },
     "@istanbuljs/schema": {
@@ -1536,9 +1544,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
     },
     "canvas": {
       "version": "2.6.1",
@@ -3153,7 +3161,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.7",
@@ -3680,6 +3689,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -3840,6 +3850,14 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
+            }
           }
         }
       }
@@ -4313,6 +4331,14 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
+            }
           }
         }
       }
@@ -5028,6 +5054,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -5042,6 +5069,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -5051,6 +5079,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -5059,13 +5088,15 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -5074,7 +5105,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6265,7 +6297,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -7594,6 +7627,13 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        }
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "homepage": "https://github.com/design-ops/sketch-to-swiftUI#readme",
   "dependencies": {
+    "camelcase": "^6.2.0",
     "decompress": "^4.2.1",
     "fontkit": "^1.8.0",
     "handlebars": "^4.7.7",


### PR DESCRIPTION
This PR allows you Mohave more than one "theme" in a sketch file by including a prefix starting with `@${name}` (e.g. @dark) in your components. 

Relates to https://github.com/design-ops/stylable-swiftui/pull/44
